### PR TITLE
Defer the MAC clear on the VF until after cmdDel() returns

### DIFF
--- a/cmd/sriov/main.go
+++ b/cmd/sriov/main.go
@@ -185,6 +185,10 @@ func cmdDel(args *skel.CmdArgs) error {
 
 	sm := sriov.NewSriovManager()
 
+	defer func() {
+		sm.ResetVFMacAddress(netConf)
+	}()
+
 	if !netConf.DPDKMode {
 		netns, err := ns.GetNS(args.Netns)
 		if err != nil {


### PR DESCRIPTION
This can help ensure a MAC clean up if cmdDel() fails